### PR TITLE
Fix GitHub username placeholders in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to this project! This document outli
 
 ```bash
 # Clone the repository
-git clone https://github.com/username/uss-wasp.git
+git clone https://github.com/imjasonh/uss-wasp.git
 cd uss-wasp
 
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # USS Wasp: Operation Beachhead Inferno
 
-[![CI](https://github.com/username/uss-wasp/actions/workflows/ci.yml/badge.svg)](https://github.com/username/uss-wasp/actions/workflows/ci.yml)
-[![AI Tests](https://github.com/username/uss-wasp/actions/workflows/ai-tests.yml/badge.svg)](https://github.com/username/uss-wasp/actions/workflows/ai-tests.yml)
+[![CI](https://github.com/imjasonh/uss-wasp/actions/workflows/ci.yml/badge.svg)](https://github.com/imjasonh/uss-wasp/actions/workflows/ci.yml)
+[![AI Tests](https://github.com/imjasonh/uss-wasp/actions/workflows/ai-tests.yml/badge.svg)](https://github.com/imjasonh/uss-wasp/actions/workflows/ai-tests.yml)
 
 A TypeScript-based tabletop wargame simulation featuring asymmetrical amphibious assault gameplay.
 


### PR DESCRIPTION
Replace 'username' placeholder with actual GitHub username 'imjasonh' in README CI badges and CONTRIBUTING clone URL.

This ensures:
- CI status badges display correctly in README
- Clone instructions in CONTRIBUTING work properly
- Documentation links point to the correct repository

Changes:
- README.md: Updated CI and AI Tests badge URLs
- CONTRIBUTING.md: Updated git clone URL

🤖 Generated with [Claude Code](https://claude.ai/code)