### PR TITLE
Fix husky deprecation warning - remove deprecated initialization lines

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 echo "🔍 Running pre-commit checks..."
 
 # Run TypeScript compilation check


### PR DESCRIPTION
## Summary
Remove the deprecated initialization lines from .husky/pre-commit that were causing deprecation warnings:
- `#!/usr/bin/env sh`
- `. ""/bin/_/husky.sh"`

## Problem
The deprecation warning was appearing on every commit:


## Solution
These lines are no longer needed in husky v9 and will cause failures in v10.0.0. The hook now starts directly with the pre-commit logic.

## Test Plan
- [x] Commit succeeds without deprecation warning
- [x] Pre-commit checks still run correctly
- [x] TypeScript compilation passes
- [x] Linting runs (warnings only, no errors)
- [x] Tests pass successfully

## Fixes
Closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)