### PR TITLE
Fix GitHub Pages deployment to only run on main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -54,7 +52,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- Fixes GitHub Pages deployment workflow to only run on main branch pushes
- Prevents PR builds from overwriting production deployments
- Removes redundant branch condition since workflow trigger is now main-only

## Changes
- Remove `pull_request` trigger from deploy.yml workflow
- Remove unnecessary `if: github.ref == 'refs/heads/main'` condition
- Ensure PR builds don't interfere with GitHub Pages site

## Test plan
- [x] Verify workflow syntax is valid
- [x] Confirm deployment only triggers on main branch pushes
- [x] Ensure PR builds no longer attempt deployment

🤖 Generated with [Claude Code](https://claude.ai/code)