### PR TITLE
Enable game-simulation tests for all PRs

### DIFF
--- a/.github/workflows/ai-tests.yml
+++ b/.github/workflows/ai-tests.yml
@@ -80,7 +80,6 @@ jobs:
 
   game-simulation:
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ai-tests.yml
+++ b/.github/workflows/ai-tests.yml
@@ -102,7 +102,7 @@ jobs:
         timeout 1200 node tests/simulation/run-full-game-simulation.js || echo "Full simulation completed (may have timed out)"
     
     - name: Upload simulation results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: simulation-results


### PR DESCRIPTION
Removes the conditional execution that was skipping game simulation tests on pull requests.

## What this changes
- Removes  condition from game-simulation job
- Game simulation tests will now run on all PRs to catch issues early

## Why this is needed
- Game simulation tests help validate complex scenarios like USS Wasp operations
- Running these tests on PRs prevents regressions from being merged
- Currently these tests only run on scheduled builds, missing potential issues in PRs

## Testing
This change enables the game-simulation test to run on this PR itself, so we can verify it works.

🤖 Generated with [Claude Code](https://claude.ai/code)