### PR TITLE
Fix Dependabot configuration deprecation warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 10
-    reviewers:
-      - "imjasonh"
     labels:
       - "dependencies"
       - "github-actions"
@@ -30,8 +28,6 @@ updates:
       day: "monday"
       time: "10:00"
     open-pull-requests-limit: 15
-    reviewers:
-      - "imjasonh"
     labels:
       - "dependencies"
       - "npm"


### PR DESCRIPTION
## Summary

Fixes Dependabot configuration issues identified in PR #63:

- ✅ **Removed deprecated `reviewers` field** - GitHub is replacing this with CODEOWNERS
- ✅ **Created missing labels** - Added `dependencies`, `npm`, and `github-actions` labels
- ✅ **Resolves Dependabot warnings** - Configuration now passes validation

## Changes Made

### 1. Updated `.github/dependabot.yml`
- Removed deprecated `reviewers` field from both GitHub Actions and npm configurations
- Configuration now uses modern format without deprecation warnings

### 2. Created Missing Labels
- `dependencies` - For all dependency updates (blue #0052cc)
- `npm` - For NPM package updates (npm red #cb3837)  
- `github-actions` - For GitHub Actions updates (GitHub blue #2088ff)

## Test Plan

- [x] Dependabot configuration validates without warnings
- [x] Labels are properly created in repository
- [x] All existing functionality preserved
- [x] Pre-commit checks pass

## References

- Addresses comments in PR #63 about Dependabot configuration issues
- Follows [GitHub's migration guide](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) for reviewers field removal

🤖 Generated with [Claude Code](https://claude.ai/code)