### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -39,7 +39,7 @@ jobs:
             This PR will be automatically merged when all CI checks pass.
             
             **Update details:**
-            - **Package**: ${{ steps.metadata.outputs.package-name }}
+            - **Package**: ${{ steps.metadata.outputs.dependency-names }}
             - **Update type**: ${{ steps.metadata.outputs.update-type }}
             - **Previous version**: ${{ steps.metadata.outputs.previous-version }}
             - **New version**: ${{ steps.metadata.outputs.new-version }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,53 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    
+    steps:
+    - name: Dependabot metadata
+      id: metadata
+      uses: dependabot/fetch-metadata@v1
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+    
+    - name: Enable auto-merge for Dependabot PRs
+      run: gh pr merge --auto --squash "$PR_URL"
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Comment on PR
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `🤖 **Dependabot Auto-Merge Enabled**
+            
+            This PR will be automatically merged when all CI checks pass.
+            
+            **Update details:**
+            - **Package**: ${{ steps.metadata.outputs.package-name }}
+            - **Update type**: ${{ steps.metadata.outputs.update-type }}
+            - **Previous version**: ${{ steps.metadata.outputs.previous-version }}
+            - **New version**: ${{ steps.metadata.outputs.new-version }}
+            
+            If you need to make changes to this PR, please disable auto-merge first by running:
+            \`\`\`
+            gh pr merge --disable-auto ${{ github.event.pull_request.number }}
+            \`\`\`
+            
+            ✅ Auto-merge will trigger once all required checks pass.`
+          })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: 'html',
   timeout: 30000,
   expect: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   timeout: 30000,
   expect: {


### PR DESCRIPTION
## Summary

Implements automated merging for Dependabot PRs after CI passes, resolving issue #75.

## Changes Made

**New GitHub Actions Workflow**: `.github/workflows/dependabot-auto-merge.yml`

- **Automatic trigger**: Only runs for PRs created by `dependabot[bot]`
- **Auto-merge enablement**: Enables auto-merge with squash for dependency updates
- **Informative comments**: Adds detailed comment with update information
- **Safety features**: Includes instructions for disabling auto-merge if needed

## Features

### 🤖 **Automated Process**
- Detects Dependabot PRs automatically
- Enables auto-merge with squash to maintain clean history
- Waits for all CI checks to pass before merging

### 📝 **Detailed Documentation**
- Comments on PR with package name, update type, and version info
- Provides clear instructions for manual intervention if needed
- Uses Dependabot metadata for accurate information

### 🔒 **Security & Safety**
- Only runs for authenticated `dependabot[bot]` actor
- Requires all CI checks to pass before merging
- Allows manual override and control when needed

## Usage

Once merged, this workflow will automatically:

1. **Detect** new Dependabot PRs
2. **Enable** auto-merge with squash
3. **Comment** with update details and instructions
4. **Wait** for CI to pass
5. **Merge** automatically when all checks succeed

## Manual Override

If you need to disable auto-merge for a specific PR:
```bash
gh pr merge --disable-auto <PR_NUMBER>
```

## Benefits

- **Reduces maintenance overhead** for routine dependency updates
- **Ensures consistent process** with required CI validation
- **Maintains clean history** with squash merge
- **Provides transparency** with detailed comments

Closes #75

🤖 Generated with [Claude Code](https://claude.ai/code)