### PR TITLE
Fix GitHub Pages deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
-        with:
-          static_site_generator: webpack
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps


### PR DESCRIPTION
## Summary
- Fixed GitHub Pages deployment by removing incompatible webpack configuration parameter
- Resolves TypeError with `actions/configure-pages@v5.0.0` 
- The `static_site_generator: webpack` parameter was causing compatibility issues

## Changes Made
- Removed the `static_site_generator` parameter from the `actions/configure-pages` action
- This allows the action to use its default static site configuration instead of trying to process webpack-specific settings

## Test Plan
- [x] Modified deployment workflow configuration
- [ ] Verify deployment workflow runs without errors on main branch
- [ ] Confirm GitHub Pages site builds and deploys successfully

## Issue Resolution
Fixes #77 - GitHub Pages deployment broken

🤖 Generated with [Claude Code](https://claude.ai/code)